### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## V0.2.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 ## V0.1.0
 Fix issue with versioning :/
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ ubersmith:
 
 Do not forget to run `st2ctl reload --register-configs` after you make changes to your `configs/ubersmith.yaml` file!
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Todo
 
 ## Requirements

--- a/actions/api_command.yaml
+++ b/actions/api_command.yaml
@@ -1,6 +1,6 @@
 ---
   name: "api_command"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Interact with Ubersmith"
   enabled: true
   entry_point: 'api_command.py'

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: ubersmith
 name: ubersmith 
 description: st2 content pack containing Ubersmith integrations.
-version: 0.1.0
+version: 0.2.0
 author: James Cornman
 email: jizaymes@gmail.com
 contributors:


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.